### PR TITLE
Fix shell timezone output

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,5 +1,5 @@
 name: Run tox tests
-on: [push, pull_request]
+on: [push]
 jobs:
   tests:
     name: Run Tests

--- a/d20/Manual/Shell.py
+++ b/d20/Manual/Shell.py
@@ -18,8 +18,8 @@ from d20.Manual.BattleMap import FileObject
 
 
 def tsTodt(input):
-    dt = datetime.datetime.fromtimestamp(input).\
-        strftime('%Y-%m-%d %H:%M:%S.%f')
+    dt = datetime.datetime.utcfromtimestamp(input).\
+        strftime('%Y-%m-%d %H:%M:%S.%f UTC')
     return dt
 
 

--- a/d20/tests/test_Shell.py
+++ b/d20/tests/test_Shell.py
@@ -34,7 +34,7 @@ class TestShellFunctions(unittest.TestCase):
 
     def testTimeString(self):
         ts = 1543509554.0126088
-        self.assertEqual(tsTodt(ts), '2018-11-29 11:39:14.012609')
+        self.assertEqual(tsTodt(ts), '2018-11-29 16:39:14.012609 UTC')
 
 
 class TestShell(unittest.TestCase):


### PR DESCRIPTION
Standardize on UTC for the shell time output