### PR TITLE
Newer versions of packages do not include type information, leverage …

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,5 +15,5 @@ deps =
     mypy
 commands =
     flake8 d20/
-    mypy --ignore-missing-imports d20/
+    mypy --install-types --non-interactive --ignore-missing-imports d20/
     pytest --cov-report term-missing --cov d20 d20/tests


### PR DESCRIPTION
…mypy to pull type packages for testing to fix tox linters env